### PR TITLE
Ansible GeoIP tasks

### DIFF
--- a/env_vars/vagrant.yml
+++ b/env_vars/vagrant.yml
@@ -51,6 +51,7 @@ requirements_file: "{{ project_path }}/requirements.txt"
 
 run_django_db_migrations: yes
 run_django_collectstatic: yes
+run_django_updategeoip: yes
 
 
 # Nginx settings.

--- a/roles/web/tasks/setup_wevote.yml
+++ b/roles/web/tasks/setup_wevote.yml
@@ -66,11 +66,6 @@
                   update_cache=true
                   state=present
 
-- name: Install autoconf package
-  apt:
-    name: autoconf
-    state: present
-
 - name: Install libgeoip1
   apt:
     name: libgeoip1

--- a/roles/web/tasks/setup_wevote.yml
+++ b/roles/web/tasks/setup_wevote.yml
@@ -60,3 +60,38 @@
   template: src=500.html
             dest={{ project_path }}/templates/500.html
             mode=0664
+
+- name: Add the MaxMind (GeoIP) PPA repository to the apt sources list
+  apt_repository: repo='ppa:maxmind/ppa'
+                  update_cache=true
+                  state=present
+
+- name: Install autoconf package
+  apt:
+    name: autoconf
+    state: present
+
+- name: Install libgeoip1
+  apt:
+    name: libgeoip1
+    state: present
+
+- name: Install libgeoip-dev
+  apt:
+    name: libgeoip-dev
+    state: present
+
+- name: Install geoip-bin
+  apt:
+    name: geoip-bin
+    state: present
+
+- name: Run GeoIP data import
+  django_manage:
+    command: update_geoip_data
+    app_path: "{{ project_path }}"
+    virtualenv: "{{ virtualenv_path }}"
+    settings: ""
+  environment: "{{ django_environment }}"
+  when: run_django_updategeoip is defined and run_django_updategeoip
+  tags: django.geoip


### PR DESCRIPTION
Adds tasks to install the [MaxMind GeoIP C API](https://github.com/maxmind/geoip-api-c), and to run the Django `update_geoip_data` job.

The data import job is enabled by default via the `run_django_updategeoip` flag in `env_vars/vagrant.yml`.