### PR TITLE
DON'T MERGE: Updates env vars Django template; tweaks to New Relic config

### DIFF
--- a/roles/newrelic/templates/gunicorn_start.j2
+++ b/roles/newrelic/templates/gunicorn_start.j2
@@ -26,10 +26,12 @@ RUNDIR=$(dirname $SOCKFILE)
 test -d $RUNDIR || mkdir -p $RUNDIR
 
 # New Relic environment vars
-NEW_RELIC_PROCESS_HOST_DISPLAY_NAME="{{ project_name }} (Dev)"
+NEW_RELIC_PROCESS_HOST_DISPLAY_NAME="{{ project_name }}-Sandbox"
 NEW_RELIC_CONFIG_FILE={{ virtualenv_path }}/etc/newrelic.ini
+NEW_RELIC_ENVIRONMENT=development
 export NEW_RELIC_PROCESS_HOST_DISPLAY_NAME
 export NEW_RELIC_CONFIG_FILE
+export NEW_RELIC_ENVIRONMENT
 
 # Programs meant to be run under supervisor should not daemonize themselves
 # (do not use --daemon).

--- a/roles/newrelic/templates/newrelic.ini.j2
+++ b/roles/newrelic/templates/newrelic.ini.j2
@@ -191,8 +191,8 @@ thread_profiler.enabled = true
 #
 
 [newrelic:development]
-app_name = {{ project_name }} (Dev)
-monitor_mode = false
+app_name = {{ project_name }}-Sandbox
+monitor_mode = true
 transaction_tracer.record_sql = {{ new_relic_sql_mode }}
 
 [newrelic:test]

--- a/roles/web/templates/environment_variables-template.json
+++ b/roles/web/templates/environment_variables-template.json
@@ -2,6 +2,7 @@
   "_comment":                       "Note that WE_VOTE_SERVER_ROOT_URL should end without slash",
   "WE_VOTE_SERVER_ROOT_URL":        "https://api.wevoteusa.org",
   "WEB_APP_ROOT_URL":               "https://WeVote.US",
+  "TIME_ZONE":                      "US/Pacific",
   "SERVER_IN_DEBUG_MODE":           true,
 
   "_comment":                       "local.py settings, including database",
@@ -11,6 +12,22 @@
   "DATABASE_PASSWORD":              "",
   "DATABASE_HOST":                  "",
   "DATABASE_PORT":                  "",
+
+  "_comment":                       "read-only database settings for local.py",
+  "DATABASE_ENGINE_READONLY":       "django.db.backends.postgresql_psycopg2",
+  "DATABASE_NAME_READONLY":         "WeVoteServerDB",
+  "DATABASE_USER_READONLY":         "postgres",
+  "DATABASE_PASSWORD_READONLY":     "",
+  "DATABASE_HOST_READONLY":         "",
+  "DATABASE_PORT_READONLY":         "",
+
+  "_comment":                       "analytics database settings for local.py",
+  "DATABASE_ENGINE_ANALYTICS":      "django.db.backends.postgresql_psycopg2",
+  "DATABASE_NAME_ANALYTICS":        "WeVoteServerDB",
+  "DATABASE_USER_ANALYTICS":        "postgres",
+  "DATABASE_PASSWORD_ANALYTICS":    "",
+  "DATABASE_HOST_ANALYTICS":        "",
+  "DATABASE_PORT_ANALYTICS":        "",
 
   "_comment":                       "The connection string for Elastic Search database",
   "ELASTIC_SEARCH_CONNECTION_STRING": "",


### PR DESCRIPTION
## WORK IN PROGRESS—DO NOT MERGE THX

## What does this PR do?

- Adds new env vars to Django template: `TIME_ZONE`, and database connection info for `READONLY` and `ANALYTICS` instances
- Fixes New Relic-enabled Gunicorn script and New Relic config file to use env vars correctly